### PR TITLE
Fixes #6: Allows multiple v8worker instances.

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -223,12 +223,14 @@ int worker_send(worker* w, const char* msg) {
   return 0;
 }
 
-worker* worker_new(worker_recv_cb cb, void* data) {
+void v8_init() {
   V8::Initialize();
 
   Platform* platform = platform::CreateDefaultPlatform();
   V8::InitializePlatform(platform);
+}
 
+worker* worker_new(worker_recv_cb cb, void* data) {
   Isolate* isolate = Isolate::New();
   Locker locker(isolate);
   Isolate::Scope isolate_scope(isolate);

--- a/binding.h
+++ b/binding.h
@@ -11,6 +11,8 @@ typedef void (*worker_recv_cb)(const char* msg, void* data);
 
 const char* worker_version();
 
+void v8_init();
+
 worker* worker_new(worker_recv_cb cb, void* data);
 
 // returns nonzero on error

--- a/worker.go
+++ b/worker.go
@@ -9,11 +9,15 @@ package v8worker
 import "C"
 import "errors"
 import "unsafe"
+import "sync"
 
 type Message string // just JSON for now...
 
 // To receive messages from javascript...
 type ReceiveMessageCallback func(msg Message)
+
+// Don't init V8 more than once.
+var initV8Once sync.Once
 
 // This is a golang wrapper around a single V8 Isolate.
 type Worker struct {
@@ -39,6 +43,10 @@ func New(cb ReceiveMessageCallback) *Worker {
 	worker := &Worker{
 		cb: cb,
 	}
+
+	initV8Once.Do(func() {
+		C.v8_init()
+	})
 
 	callback := C.worker_recv_cb(C.go_recv_cb)
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -56,3 +56,29 @@ func TestBasic(t *testing.T) {
 		t.Fatal("bad recvCount", recvCount)
 	}
 }
+
+func TestMultipleWorkers(t *testing.T) {
+	recvCount := 0
+	worker1 := New(func(msg Message) {
+		println("w1", msg)
+		recvCount++
+	})
+	worker2 := New(func(msg Message) {
+		println("w2", msg)
+		recvCount++
+	})
+
+	err := worker1.Load("1.js", `$send("hello1")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = worker2.Load("2.js", `$send("hello2")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if recvCount != 2 {
+		t.Fatal("bad recvCount", recvCount)
+	}
+}


### PR DESCRIPTION
Calling V8::InitializePlatform() should only be done once per process.
